### PR TITLE
REPO-3040 Remove dependency on external version.properties

### DIFF
--- a/alfresco-ftr-distribution/pom.xml
+++ b/alfresco-ftr-distribution/pom.xml
@@ -84,30 +84,6 @@
             </plugin>
 
             <plugin>
-                <artifactId>maven-dependency-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>unpack-version.properties</id>
-                        <phase>prepare-package</phase>
-                        <goals>
-                            <goal>unpack</goal>
-                        </goals>
-                        <configuration>
-                            <artifactItems>
-                                <artifactItem>
-                                    <groupId>org.alfresco</groupId>
-                                    <artifactId>content-services-community</artifactId>
-                                    <version>${dependency.content-services-community.version}</version>
-                                    <type>war</type>
-                                    <includes>WEB-INF/classes/alfresco/version.properties</includes>
-                                </artifactItem>
-                            </artifactItems>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-
-            <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <executions>
                     <execution>

--- a/alfresco-ftr-distribution/src/assembly/ftr-distribution.xml
+++ b/alfresco-ftr-distribution/src/assembly/ftr-distribution.xml
@@ -18,10 +18,6 @@
             <outputDirectory></outputDirectory>
             <destName>file-transfer-receiver.jar</destName>
         </file>
-        <file>
-            <source>${project.build.directory}/dependency/WEB-INF/classes/alfresco/version.properties</source>
-            <outputDirectory></outputDirectory>
-        </file>
     </files>
     <dependencySets>
         <dependencySet>

--- a/alfresco-ftr/pom.xml
+++ b/alfresco-ftr/pom.xml
@@ -92,6 +92,19 @@
                     </dependency>
                 </dependencies>
             </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>3.0.0</version>
+                <executions>
+                    <execution>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>parse-version</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
 
         <pluginManagement>
@@ -105,8 +118,19 @@
         </pluginManagement>
 
         <resources>
+            <!-- Allow replacing variables inside version.properties -->
             <resource>
                 <directory>src/main/resources</directory>
+                <excludes>
+                    <exclude>version.properties</exclude>
+                </excludes>
+            </resource>
+            <resource>
+                <directory>src/main/resources</directory>
+                <includes>
+                    <include>version.properties</include>
+                </includes>
+                <filtering>true</filtering>
             </resource>
         </resources>
     </build>

--- a/alfresco-ftr/pom.xml
+++ b/alfresco-ftr/pom.xml
@@ -57,29 +57,6 @@
 
     <build>
         <plugins>
-            <!-- Fetch version.properties in alfresco-repository -->
-            <plugin>
-                <artifactId>maven-dependency-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>fetch-version-properties</id>
-                        <phase>generate-resources</phase>
-                        <goals>
-                            <goal>unpack</goal>
-                        </goals>
-                        <configuration>
-                            <artifactItems>
-                                <artifactItem>
-                                    <groupId>org.alfresco</groupId>
-                                    <artifactId>alfresco-repository</artifactId>
-                                    <version>${dependency.alfresco-repository.version}</version>
-                                </artifactItem>
-                            </artifactItems>
-                            <includes>alfresco/version.properties</includes>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>license-maven-plugin</artifactId>
@@ -130,10 +107,6 @@
         <resources>
             <resource>
                 <directory>src/main/resources</directory>
-            </resource>
-            <!-- Additional resource folder where version.properties was extracted -->
-            <resource>
-                <directory>${project.build.directory}/dependency/alfresco</directory>
             </resource>
         </resources>
     </build>

--- a/alfresco-ftr/src/main/resources/version.properties
+++ b/alfresco-ftr/src/main/resources/version.properties
@@ -4,7 +4,7 @@
 
 # Version label
 
-version.major=6
-version.minor=0
-version.revision=0
+version.major=@parsedVersion.majorVersion@
+version.minor=@parsedVersion.minorVersion@
+version.revision=@parsedVersion.incrementalVersion@
 version.label=

--- a/alfresco-ftr/src/main/resources/version.properties
+++ b/alfresco-ftr/src/main/resources/version.properties
@@ -1,0 +1,10 @@
+#
+# FTR version information
+#
+
+# Version label
+
+version.major=6
+version.minor=0
+version.revision=0
+version.label=

--- a/alfresco-ftr/src/main/resources/version.properties
+++ b/alfresco-ftr/src/main/resources/version.properties
@@ -8,3 +8,5 @@ version.major=@parsedVersion.majorVersion@
 version.minor=@parsedVersion.minorVersion@
 version.revision=@parsedVersion.incrementalVersion@
 version.label=
+
+version.edition=FTR

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,6 @@
 
         <dependency.alfresco-repository.version>6.4</dependency.alfresco-repository.version>
         <dependency.alfresco-remote-api.version>6.2</dependency.alfresco-remote-api.version>
-        <dependency.content-services-community.version>6.0.a</dependency.content-services-community.version>
 
         <dependency.spring.version>3.2.17.RELEASE</dependency.spring.version>
         <dependency.tomcat.version>7.0.82</dependency.tomcat.version>


### PR DESCRIPTION
FTR now has it's own version.properties
The file is used to check if the transfer can be done, comparing the major version (6 in this case).