### PR TITLE
ACS-5160 Identify the correct version for S3 GA release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           persist-credentials: false
+          fetch-depth: 0
       - name: "Configure AWS credentials"
         uses: aws-actions/configure-aws-credentials@v1
         with:


### PR DESCRIPTION
Adding the `fetch-depth` option to allow the `copy_to_release_bucket.sh` script to fetch the latest tag and identify the GA version to release via S3 copy.